### PR TITLE
Add historic revision of source article

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -51,4 +51,6 @@ end
 
 ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil
 scrape_list(2011, 'https://en.wikipedia.org/w/index.php?title=Constituencies_of_Jamaica&oldid=707616860')
+scrape_list(2016, 'https://en.wikipedia.org/w/index.php?title=Constituencies_of_Jamaica&direction=prev&oldid=734761830')
 scrape_list(2016, 'https://en.wikipedia.org/wiki/Constituencies_of_Jamaica')
+


### PR DESCRIPTION
A member -- Roger Clarke -- has died and is no longer listed in the source article. This commit adds a historic revision of the article, in which the member is still listed.

https://en.wikipedia.org/w/index.php?title=Constituencies_of_Jamaica&direction=prev&oldid=734761830

The revision in which the member is listed points to the member's page. The member's wikidata item (Q1314683) lists his data of death.